### PR TITLE
Completely disable cache and fix reloading problem

### DIFF
--- a/android-webview-app/app/src/main/java/com/novoda/dashboards/DashboardActivity.java
+++ b/android-webview-app/app/src/main/java/com/novoda/dashboards/DashboardActivity.java
@@ -6,6 +6,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.WindowManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 public class DashboardActivity extends AppCompatActivity {
 
@@ -17,6 +18,7 @@ public class DashboardActivity extends AppCompatActivity {
         setContentView(R.layout.dashboard);
 
         WebView webView = (WebView) findViewById(R.id.webview);
+        webView.clearCache(true);
         webView.loadUrl(Preferences.from(this).getUrl());
         webView.getSettings().setUseWideViewPort(true);
         webView.setInitialScale(1);
@@ -24,6 +26,10 @@ public class DashboardActivity extends AppCompatActivity {
         WebSettings webSettings = webView.getSettings();
         webSettings.setJavaScriptEnabled(true);
         webSettings.setLoadWithOverviewMode(true);
+        webSettings.setAppCacheEnabled(false);
+        webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
+
+        webView.setWebViewClient(new WebViewClient()); // Fixes js reload on Fire TV Stick
     }
 
 }


### PR DESCRIPTION
We had 2 problems:

 1. We couldn't trigger a remote refresh because the Fire TV Stick was showing an error dialog every time we tried it, this was odd and the fix was to just set a `WebViewClient` on the `WebView`
 2. The `WebView` was hard-caching everything so upon refresh we would get a cached version instead of the latest sources, 'fixed' by forcing the `WebView` to not use cache at all. We'll look at doing this server-side in the future.