### PR TITLE
PT-321: Better slack server

### DIFF
--- a/node-server/server/widget/slacker/slacker.js
+++ b/node-server/server/widget/slacker/slacker.js
@@ -12,7 +12,6 @@ var rules = [
 
 var Slacker = function(config) {
   this.messages = [];
-  this.index = 0;
   this.ruleIndex = 0;
   this.rtm = new RtmClient(
     config.token,
@@ -28,12 +27,20 @@ function messageHandler(self, callback) {
       console.log('message ignored');
       return;
     }
-    if (self.index === 100) {
-      self.index = 0;
+    if (self.messages.length > 0 && !isSameDayFor(message, self.messages[0])) {
+      self.messages.length = 0;
     }
-    self.messages.splice(self.index, 0 , message);
-    self.index++;
+    self.messages.push(message);
   }
+}
+
+function isSameDayFor(message1, message2) {
+  return formatDateFor(message1) === formatDateFor(message2);
+}
+
+function formatDateFor(message) {
+  var date = new Date(Math.floor(message.ts)*1000);
+  return date.getDate()  + "-" + date.getMonth() + "-" + date.getFullYear();
 }
 
 function ignored(message) {

--- a/node-server/server/widget/slacker/slacker.js
+++ b/node-server/server/widget/slacker/slacker.js
@@ -39,7 +39,7 @@ function isSameDayFor(message1, message2) {
 }
 
 function formatDateFor(message) {
-  var date = new Date(Math.floor(message.ts)*1000);
+  var date = new Date(Math.floor(message.ts) * 1000);
   return date.getDate()  + "-" + date.getMonth() + "-" + date.getFullYear();
 }
 

--- a/run_da.sh
+++ b/run_da.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+$TERMINAL -e bash -c "cd node-server && npm start"&
+$TERMINAL -e bash -c "cd angular2-client && npm start"&

--- a/run_da.sh
+++ b/run_da.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-$TERMINAL -e bash -c "cd node-server && npm start"&
-$TERMINAL -e bash -c "cd angular2-client && npm start"&


### PR DESCRIPTION
> Tracked in JIRA by [PT-321](https://novoda.atlassian.net/browse/PT-321)

### Scope of the PR

Slacker now keeps all the slack message that happened this day and clear them the next day. This way we have a more precise "biggest slacker" and don't miss "thanks" and "gallery" messages because of high turnover (before it was only keeping the last 100 messages in memory).

Also add a script to start automatically server and client (not sure how this would work on OSX, sorry).