### PR TITLE
Add test template to plugin tester init template

### DIFF
--- a/plugin-tester/template/package.json
+++ b/plugin-tester/template/package.json
@@ -6,5 +6,15 @@
   "license": "MIT",
   "dependencies": {
     "dashboard-plugin": "https://github.com/novoda/dashboards/blob/master/plugin/dashboard-plugin-1.0.3.tgz?raw=true"
-  }
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^5.0.1"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "directories": {
+    "test": "test"
+  } 
 }

--- a/plugin-tester/template/test/test.js
+++ b/plugin-tester/template/test/test.js
@@ -1,0 +1,25 @@
+const expect = require('chai').expect;
+const ds = require('../lib/data-source')
+
+describe('generateViewState', function () {
+    const configuration = {
+        foo: {
+            value: "foo value"
+        },
+        bar: {
+            value: 1
+        }
+    }
+
+    it('viewstate foo string value is read from configuration', function () {
+        return ds(configuration).then(result => {
+            expect(result.foo).to.be.equal("foo value");
+        }) 
+    })
+
+    it('viewstate bar int value is read from configuration', function () {
+        return ds(configuration).then(result => {
+            expect(result.bar).to.be.equal(1);
+        }) 
+    })
+})


### PR DESCRIPTION
This PR adds to the bootstrap template:

* Mocha a test framework for node: https://mochajs.org/
* Chai an assertion library for node: http://chaijs.com/

The generated plugin structure is now:

```
- <plugin>
  - /lib
    - data-source.js
  - /test
    - test.js
```
To run the tests you just need to do: npm test