### PR TITLE
Add console output to plugin-tester init

### DIFF
--- a/plugin-tester/src/template.js
+++ b/plugin-tester/src/template.js
@@ -24,12 +24,15 @@ const template = (templatePath, viewState, file) => {
 }
 
 const createTemplate = name => {
+    console.log("Creating plugin... ", name);
+
     const viewState = {
         pluginName: name,
         pluginId: name.toLowerCase().replace(/\s+/g, '-')
     }
     const pluginPath = path.join(process.cwd(), name)
     fs.mkdirSync(pluginPath)
+    console.log("> mkdir ", pluginPath);
     const templatePath = path.join(__dirname, '../template')
     const options = {
         cwd: templatePath,
@@ -41,7 +44,9 @@ const createTemplate = name => {
         const templatedFilePath = path.join(pluginPath, file)
         ensureDirectoryExistence(templatedFilePath)
         fs.writeFileSync(templatedFilePath, templatedContent)
+        console.log("> created file ", templatedFilePath);
     })
+    console.log("Creating plugin... done");
 }
 
 


### PR DESCRIPTION
At the moment `plugin-tester init` gives the user no feedback of what it's doing. 

This PR adds logs to let the user know something is happening. Makes it easier to spot when something goes wrong

`> plugin-tester init luis-plugin-one`
``` 
Creating plugin...  luis-plugin-one
> mkdir  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/config.json
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/lib/data-source.js
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/lib/index.js
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/lib/plugin.js
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/lib/style.css
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/lib/template.html
> created file  /Users/luis/Developer/workspace/dashboard-plugins/luis-plugin-one/package.json
Creating plugin... done
```