### PR TITLE
Rerender plugin on config changes

### DIFF
--- a/plugin-tester/src/index.js
+++ b/plugin-tester/src/index.js
@@ -49,6 +49,9 @@ const runPlugin = (pluginPath, options) => {
     if (options.watch) {
         const watch = createWatcher(pluginRunner)
         watch(pluginPath)
+        if (options.config) {
+            watch(resolveConfigPath(options.config))
+        }
     }
 }
 

--- a/plugin-tester/src/index.js
+++ b/plugin-tester/src/index.js
@@ -15,12 +15,16 @@ program.command('init <name>')
         template.createTemplate(name)
     })
 
-const readConfig = (pluginPath, options) => {
+const readJson = path => {
+    return JSON.parse(fs.readFileSync(path))
+}
+
+const readConfig = (pluginPath, options) => () => {
     const configPath = path.join(pluginPath, 'config.json')
     if (options.config) {
-        return require(path.resolve(options.config))
+        return readJson(resolveConfigPath(options.config))
     } else if (fs.existsSync(configPath)) {
-        return require(configPath)
+        return readJson(configPath)
     } else {
         return {}
     }

--- a/plugin-tester/src/index.js
+++ b/plugin-tester/src/index.js
@@ -15,11 +15,15 @@ program.command('init <name>')
         template.createTemplate(name)
     })
 
+const resolveConfigPath = config => {
+    return path.resolve(config)
+}
+
 const readJson = path => {
     return JSON.parse(fs.readFileSync(path))
 }
 
-const readConfig = (pluginPath, options) => () => {
+const createConfigReader = (pluginPath, options) => () => {
     const configPath = path.join(pluginPath, 'config.json')
     if (options.config) {
         return readJson(resolveConfigPath(options.config))
@@ -30,16 +34,21 @@ const readConfig = (pluginPath, options) => () => {
     }
 }
 
+const createWatcher = onChange => location => {
+    chokidar
+        .watch(location, { ignored: /(^|[\/\\])\../ })
+        .on('change', onChange)
+}
+
 const runPlugin = (pluginPath, options) => {
     const port = options.port || 5000
-    const config = readConfig(pluginPath, options)
-    const pluginRunner = runnerCreator.local(pluginPath, port, config)
+    const configReader = createConfigReader(pluginPath, options)
+    const pluginRunner = runnerCreator.local(pluginPath, port, configReader)
     const server = new Server(port, pluginRunner)
     server.start()
     if (options.watch) {
-        chokidar
-            .watch(pluginPath, { ignored: /(^|[\/\\])\../ })
-            .on('change', pluginRunner)
+        const watch = createWatcher(pluginRunner)
+        watch(pluginPath)
     }
 }
 

--- a/plugin-tester/src/runner.js
+++ b/plugin-tester/src/runner.js
@@ -1,39 +1,23 @@
 const http = require('request-promise-native')
 const decache = require('decache')
 
-const createRequestBody = (port, pluginConfig) => {
-    return {
-        type: 'query',
-        callbackUrl: `http://localhost:${port}/callback`,
-        configuration: pluginConfig
-    }
-}
-
-const localPlugin = (localPath, query) => () => {
-    const request = {
-        body: query
-    }
-    const response = {
-        status: () => {
-            return {
-                send: (message) => { }
-            }
+const ignoredResponse = {
+    status: () => {
+        return {
+            send: (message) => { }
         }
     }
-    decache(localPath);
-    return require(localPath).plugin()(request, response)
 }
 
-const hostedPlugin = (url, query) => () => {
+module.exports.local = (path, port, configReader) => () => {
+    const config = configReader()
     const request = {
-        url: url,
-        body: query,
-        json: true
+        body: {
+            type: 'query',
+            callbackUrl: `http://localhost:${port}/callback`,
+            configuration: config
+        }
     }
-    return http.post(request)
-}
-
-module.exports.local = (path, port, pluginConfig) => {
-    const query = createRequestBody(port, pluginConfig)
-    return localPlugin(path, query)
+    decache(path)
+    return require(path).plugin()(request, ignoredResponse)
 }


### PR DESCRIPTION
Fixes #21 

Allows the plugin-tester to rerender whenever a `config.json` change is made.

This also fixes a bug/missing scenario where custom path `config.jsons` were not being watched.